### PR TITLE
Support array indexes in path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "doc-path",
-    "version": "4.0.2",
+    "version": "4.1.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "doc-path",
-            "version": "4.0.2",
+            "version": "4.1.0",
             "license": "MIT",
             "devDependencies": {
                 "@types/mocha": "10.0.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "author": "mrodrig",
     "name": "doc-path",
     "description": "A document path library for Node",
-    "version": "4.0.2",
+    "version": "4.1.0",
     "homepage": "https://mrodrig.github.io/doc-path",
     "repository": {
         "type": "git",

--- a/src/path.ts
+++ b/src/path.ts
@@ -18,25 +18,42 @@ export function evaluatePath(obj: unknown, kp: string): unknown {
     const kpVal = typeof obj === 'object' && kp in obj ? (obj as Record<string, unknown>)[kp] : undefined;
     const keyVal = typeof obj === 'object' && key in obj ? (obj as Record<string, unknown>)[key] : undefined;
 
-    // If there is a '.' in the key path and the key path doesn't appear in the object, recur on the subobject
+    console.log(`KP=${kp}, remaining=${remaining}, dotIndex=${dotIndex}, key=${key}, kp in obj =${(typeof obj === 'object' && kp in obj)}`);
+
     if (dotIndex >= 0 && typeof obj === 'object' && !(kp in obj)) {
+        const { key: nextKey } = state(remaining);
+        const nextKeyAsInt = parseInt(nextKey);
+
+        console.log(`  nextKeyAsInt=${nextKeyAsInt}\tisNaN=${isNaN(nextKeyAsInt)}`);
         // If there's an array at the current key in the object, then iterate over those items evaluating the remaining path
-        if (Array.isArray(keyVal)) {
+        if (Array.isArray(keyVal) && isNaN(nextKeyAsInt)) {
+            console.log('  case 1.1');
             return keyVal.map((doc: unknown) => evaluatePath(doc, remaining));
         }
+        console.log('  case 1.2', {keyVal, remaining});
         // Otherwise, we can just recur
         return evaluatePath(keyVal, remaining);
     } else if (Array.isArray(obj)) {
+        const keyAsInt = parseInt(key);
+        if (kp === key && dotIndex === -1 && !isNaN(keyAsInt)) {
+            console.log('  case 2.1');
+            return keyVal;
+        }
+
+        console.log('  case 2.2');
         // If this object is actually an array, then iterate over those items evaluating the path
         return obj.map((doc) => evaluatePath(doc, kp));
     } else if (dotIndex >= 0 && kp !== key && typeof obj === 'object' && key in obj) {
+        console.log('  case 3');
         // If there's a field with a non-nested dot, then recur into that sub-value
         return evaluatePath(keyVal, remaining);
     } else if (dotIndex === -1 && typeof obj === 'object' && key in obj && !(kp in obj)) {
+        console.log('  case 4');
         // If the field is here, but the key was escaped
         return keyVal;
     }
 
+    console.log('  default');
     // Otherwise, we can just return value directly
     return kpVal;
 }

--- a/src/path.ts
+++ b/src/path.ts
@@ -78,9 +78,7 @@ function _sp<T>(obj: T, kp: string, v: unknown): T {
         if (typeof obj === 'object' && obj !== null && !(key in obj) && Array.isArray(obj) && !isNaN(keyAsInt)) {
 
             // If there's no value at obj[key] then populate an empty object
-            if (!(obj as Record<string, unknown>)[key]) {
-                (obj as Record<string, unknown>)[key] = {};
-            }
+            (obj as Record<string, unknown>)[key] = (obj as Record<string, unknown>)[key] ?? {};
             
             // Continue iterating on the rest of the key path to set the appropriate value where intended and then return
             _sp((obj as Record<string, unknown>)[key], remaining, v);

--- a/test/index.ts
+++ b/test/index.ts
@@ -174,6 +174,52 @@ describe('doc-path Module', () => {
 
             done();
         });
+
+        it('should evaluate the properties within an array properly', (done) => {
+            doc = {
+                list: [{
+                    a: 1
+                }, {
+                    a: 2
+                }]
+            };
+            
+            assert.deepEqual(evaluatePath(doc, 'list.a'), [1, 2]);
+
+            done();
+        });
+
+        it('should evaluate the property even when an array index is included in the path', (done) => {
+            doc = {
+                list: [{
+                    a: 1
+                }, {
+                    a: 2
+                }]
+            };
+            
+            assert.equal(evaluatePath(doc, 'list.0.a'), 1);
+            assert.equal(evaluatePath(doc, 'list.1.a'), 2);
+            assert.equal(evaluatePath(doc, 'list.2.a'), undefined);
+
+
+            done();
+        });
+
+        it('should evaluate the property even when an array index is the last key in the path', (done) => {
+            doc = {
+                list: [{
+                    a: 1
+                }, {
+                    a: 2
+                }]
+            };
+            
+            assert.deepEqual(evaluatePath(doc, 'list.0'), { a: 1 });
+            assert.deepEqual(evaluatePath(doc, 'list.2'), undefined);
+
+            done();
+        });
     });
 
     describe('setPath', () => {
@@ -398,6 +444,28 @@ describe('doc-path Module', () => {
             setPath(doc, 'data.options.name', 'MacBook Pro 15');
             assert.equal(doc.data.category, 'Computers');
             assert.equal(doc.data.options.name, 'MacBook Pro 15');
+            done();
+        });
+
+        it('should set a value properly when an array index is specified in the key path', (done) => {
+            setPath(doc, 'list.0.a', '1');
+            setPath(doc, 'list.1.a', '2');
+            assert.deepEqual(doc, {list: [ {a: 1}, {a: 2} ]});
+            done();
+        });
+
+        it('should set a value properly when an array index is specified in the key path', (done) => {
+            setPath(doc, 'list.test.0.a', '1');
+            setPath(doc, 'list.test.1', '2');
+            assert.deepEqual(doc, {list: {test: [ {a: 1}, 2 ]}});
+            done();
+        });
+
+        it('should set a value properly when an array index is specified in the key path - beyond first index', (done) => {
+            setPath(doc, 'list.1.a', '2');
+            const expected = { list: [] };
+            (expected.list[1] as unknown) = {a: 2};
+            assert.deepEqual(doc, expected);
             done();
         });
     });


### PR DESCRIPTION
Adds support for array indexes inside key paths for both evaluatePath and setPath to help add support for the desired behavior in: https://github.com/mrodrig/json-2-csv/issues/207