### PR TITLE
Properly handle key paths with `.` at end

### DIFF
--- a/src/path.ts
+++ b/src/path.ts
@@ -95,6 +95,10 @@ function _sp<T>(obj: T, kp: string, v: unknown): T {
             if (!isNaN(nextKeyAsInt)) {
                 // If the current key doesn't exist yet and the next key is a number (likely array index), populate an empty array
                 (obj as Record<string, unknown>)[key] = [];
+            } else if (remaining === '') {
+                // If the remaining key is empty, then a `.` character appeared right at the end of the path and wasn't actually indicating a separate level
+                (obj as Record<string, unknown>)[kp] = v;
+                return obj;
             } else {
                 // If the current key doesn't exist yet, populate it
                 (obj as Record<string, unknown>)[key] = {};

--- a/test/index.ts
+++ b/test/index.ts
@@ -468,5 +468,17 @@ describe('doc-path Module', () => {
             assert.deepEqual(doc, expected);
             done();
         });
+
+        it('should handle a trailing `.` character in the key path as part of the key rather than as a separate key level - single level', (done) => {
+            setPath(doc, 'Account No.', '1');
+            assert.deepEqual(doc, { 'Account No.': '1' });
+            done();
+        });
+
+        it('should handle a trailing `.` character in the key path as part of the key rather than as a separate key level - multiple levels', (done) => {
+            setPath(doc, 'user.Account No.', '1');
+            assert.deepEqual(doc, { user: { 'Account No.': '1' } });
+            done();
+        });
     });
 });


### PR DESCRIPTION
Resolves the issue raised in #39 and originally https://github.com/mrodrig/json-2-csv/issues/254